### PR TITLE
fix shell-escape syntax typo

### DIFF
--- a/lib/PdfMerge.js
+++ b/lib/PdfMerge.js
@@ -72,7 +72,7 @@ function assembleExecArgs() {
 			return shellescape([file]);
 		}.bind(this))
 		.value();
-	execArgs.push('cat', 'output', this.isWin ? tmpFilePath : shellescape[tmpFilePath]);
+	execArgs.push('cat', 'output', this.isWin ? tmpFilePath : shellescape([tmpFilePath]));
 	return execArgs;
 }
 


### PR DESCRIPTION
pdf-merge doesn't work since 0.0.3 on all systems except Windows