### PR TITLE
pdftkPath is now not required on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pdfMerge
 ### Usage
 By default, pdf-merge will always return a Buffer of the merged PDF document. It does however support ReadStreams and Save-to-File as well. Read the API below.
 
-**NOTE:** If you are on a Windows platform, you **have** to specify the absolute path to `pdftk.exe`. If you are **not** on Windows platform, the second argument is ignored.
+**NOTE:** If you are on a Windows platform, you can specify the absolute path to `pdftk.exe`, but it is not necessary if PDFtk was properly installed and its path was added to PATH environment variable.
 
 ```javascript
 var PDFMerge = require('pdf-merge');

--- a/lib/PdfMerge.js
+++ b/lib/PdfMerge.js
@@ -20,16 +20,14 @@ function PDFMerge(pdfFiles, pdftkPath) {
 		throw new Error('pdfFiles must be an array of absolute file paths.');
 	}
 
+	this.pdftkPath = pdftkPath;
+	if(pdftkPath && !fs.existsSync(pdftkPath)) {
+		throw new Error('Path to PDFtk is incorrect.');
+	}
+
 	//Windows: Demand path to lib
 	if(isWindowsPlatform()) {
-		this.exec = child.execFile;
-		if(!pdftkPath || !fs.existsSync(pdftkPath)) {
-			throw new Error('Path to PDFtk is incorrect.');
-		}
-		this.pdftkPath = pdftkPath;
-		this.isWin     = true;
-	} else {
-		this.exec = child.exec;
+		this.isWin = true;
 	}
 
 	//Array of files
@@ -141,10 +139,10 @@ PDFMerge.prototype.merge = function(callback) {
 	var newFilePath = this.newFilePath; //MODE === 'NEWFILE'
 
 	//Windows or not, different syntax
-	if(this.isWin) {
-		this.exec(this.pdftkPath, this.execArgs, execCallbackHandler)
+	if(this.pdftkPath) {
+		child.execFile(this.pdftkPath, this.execArgs, execCallbackHandler)
 	} else {
-		this.exec('pdftk ' + this.execArgs.join(' '), execCallbackHandler);
+		child.exec('pdftk ' + this.execArgs.join(' '), execCallbackHandler);
 	}
 
 	/**


### PR DESCRIPTION
pdftkPath is now not required on Windows (when pdftk is listed in PATH environment variable - which is happens when you run the installer)