### PR TITLE
Support pdftkPath for no windows platform

### DIFF
--- a/lib/PdfMerge.js
+++ b/lib/PdfMerge.js
@@ -139,8 +139,10 @@ PDFMerge.prototype.merge = function(callback) {
 	var newFilePath = this.newFilePath; //MODE === 'NEWFILE'
 
 	//Windows or not, different syntax
-	if(this.pdftkPath) {
+	if(this.isWin && this.pdftkPath) {
 		child.execFile(this.pdftkPath, this.execArgs, execCallbackHandler)
+	} else if(this.pdftkPath) {
+		child.exec(this.pdftkPath + ' ' + this.execArgs.join(' '), execCallbackHandler);
 	} else {
 		child.exec('pdftk ' + this.execArgs.join(' '), execCallbackHandler);
 	}


### PR DESCRIPTION
If we specify pdftkPath and platform is not windows, it's not necessary to use execFile instead exec. I'd like to do this change because I need to specify pdftk path on linux platform as I don't install pdftk with apt-get command. This is usefull when pdftk is used on cloud platforms as AWS or Heroku.