### PR TITLE
:sparkles: - pdf merge now works on arrays of length 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,7 @@ module.exports = (files, options) => new Promise((resolve, reject) => {
     return;
   }
 
-  options = Object.assign({
-    libPath: 'pdftk',
-    output:  Buffer,
-  }, options);
-
-  if (files.length === 1){
+  if(files.length === 1){
     readFile(files[0])
     .then((buffer) => {
       return output(buffer);
@@ -43,6 +38,11 @@ module.exports = (files, options) => new Promise((resolve, reject) => {
     .then(resolve)
     .catch(reject);
   }
+
+  options = Object.assign({
+    libPath: 'pdftk',
+    output:  Buffer,
+  }, options);
 
   const tmpFilePath = isWindows
     ? tmp.tmpNameSync()

--- a/index.js
+++ b/index.js
@@ -30,12 +30,6 @@ module.exports = (files, options) => new Promise((resolve, reject) => {
     return;
   }
 
-  if(files.length === 1) {
-    reject(new Error('You need at least two files in order to merge PDF documents.'));
-
-    return;
-  }
-
   options = Object.assign({
     libPath: 'pdftk',
     output:  Buffer,

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -78,22 +78,14 @@ describe('PDFMerge', () => {
 					return true;
 				})
 		);
-
-		it('Ensures at least two files are submitted for merging', () =>
-			PDFMerge([pdf1], {})
-				.then(() => {
-					throw new Error('Should have thrown error')
-				})
-				.catch((error) => {
-					expect(error instanceof Error).toEqual(true);
-					expect(error.message).toEqual('You need at least two files in order to merge PDF documents.');
-
-					return true;
-				})
-		);
 	});
 
 	describe('Buffer', () => {
+		it('Can merge one document', () =>
+			PDFMerge([pdf1], {})
+				.then(assertPageCount(1))
+		);
+
 		it('Can merge two documents', () =>
 			PDFMerge([pdf1, pdf2], {})
 				.then(assertPageCount(2))
@@ -111,6 +103,13 @@ describe('PDFMerge', () => {
 	});
 
 	describe('Stream', () => {
+		it('Can merge one documents', () =>
+			PDFMerge([pdf1], {output: 'Stream'})
+				.then((stream) =>
+					assertPageCount(1)(stream.read())
+				)
+		);
+
 		it('Can merge two documents', () =>
 			PDFMerge([pdf1, pdf2], {output: 'Stream'})
 				.then((stream) =>
@@ -134,6 +133,15 @@ describe('PDFMerge', () => {
 	});
 
 	describe('File', () => {
+		it('Can merge one document', () =>
+			PDFMerge([pdf1], {output: `${__dirname}/files/out/File1.pdf`})
+				.then((buffer) => {
+					expect(fs.existsSync(`${__dirname}/files/out/File1.pdf`)).toEqual(true);
+
+					return assertPageCount(1)(buffer);
+				})
+		)
+
 		it('Can merge two documents', () =>
 			PDFMerge([pdf1, pdf2], {output: `${__dirname}/files/out/File1.pdf`})
 				.then((buffer) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -103,7 +103,7 @@ describe('PDFMerge', () => {
 	});
 
 	describe('Stream', () => {
-		it('Can merge one documents', () =>
+		it('Can merge one document', () =>
 			PDFMerge([pdf1], {output: 'Stream'})
 				.then((stream) =>
 					assertPageCount(1)(stream.read())


### PR DESCRIPTION
I think you should reconsider throwing an error in the case the array is equal to length 1

Although it makes no difference just merging one document, if the case ever does come up it is better to just let it run instead of throwing an error

For example, the code I am working with the input to pdf merge is based on the size of the users document. If their document only has 1 page pdf-merge will throw an error

